### PR TITLE
Fix NLP parsers to exclude conditionals and include above/below as ne…

### DIFF
--- a/crate_anon/nlp_manager/parse_biochemistry.py
+++ b/crate_anon/nlp_manager/parse_biochemistry.py
@@ -191,6 +191,19 @@ class Crp(SimpleNumericalResultParser):
                 ("Plasma C-reactive protein level (XE2dy) 45 mg/L", [45]),
                 ("Serum C reactive protein level (XaINL) 45 mg/L", [45]),
                 ("CRP (mg/L) 62", [62]),
+                (
+                    "If CRP is over 30 mg/L the ferritin result may be high "
+                    "and uninterpretable",
+                    [],
+                ),  # conditional
+                ("If the CRP is over 30 mg/L", []),  # conditional
+                ("The CRP is over 30 mg/L", [30]),
+                ("When the CRP is over 30 mg/L", []),  # conditional
+                ("The CRP is above 30 mg/L", [30]),
+                ("The CRP is over 30 mg/L", [30]),
+                ("The CRP is less than 30 mg/L", [30]),
+                ("The CRP is under 30 mg/L", [30]),
+                ("The CRP is below 30 mg/L", [30]),
             ],
             verbose=verbose,
         )

--- a/crate_anon/nlp_manager/regex_parser.py
+++ b/crate_anon/nlp_manager/regex_parser.py
@@ -65,6 +65,30 @@ log = logging.getLogger(__name__)
 # =============================================================================
 # Generic entities
 # =============================================================================
+# https://docs.python.org/3/library/re.html
+# https://github.com/mrabarnett/mrab-regex
+#
+# Reminders:
+#   (abc)               capture group
+#   (?P<groupname>abc)  named capture group
+#   (?:abc)             non-capturing group
+#   (?!abc)             negative lookahead
+#   (?<!abc)            negative lookbehind
+
+# -----------------------------------------------------------------------------
+# Exclude a preceding "if" clause, e.g. "if [the] CRP is over <value>..."
+# -----------------------------------------------------------------------------
+
+# This uses a negative lookbehind, as it is normally placed immediately before
+# the regex for the quantity of interest (e.g. CRP).
+EXCLUDE_PRECEDING_CONDITIONAL_CLAUSE = r"""
+    (?<!  # EXCLUDE_PRECEDING_CONDITIONAL_CLAUSE
+        \b(?:if|when)\b     # conditionality
+        \s*                 # optional whitespace
+        (\bthe\b)?          # optional "the"
+        \s+                 # whitespace between clause and what follows
+    )
+"""
 
 # -----------------------------------------------------------------------------
 # Blood results
@@ -145,11 +169,11 @@ TENSE_LOOKUP = compile_regex_dict(
 # -----------------------------------------------------------------------------
 # ... don't use unnamed groups here; EQ is also used as a return value
 
-LT = r"(?: < | less \s+ than | under )"
+LT = r"(?: < | less \s+ than | under | below )"
 LE = "<="
 EQ = r"(?: = | equals | equal \s+ to )"
 GE = ">="
-GT = r"(?: > | (?:more|greater) \s+ than | over )"
+GT = r"(?: > | (?:more|greater) \s+ than | over | above )"
 # OF = "\b of \b"  # as in: "a BMI of 30"... but too likely to be mistaken for a target?  # noqa: E501
 
 RELATION = rf"(?: {LE} | {LT} | {EQ} | {GE} | {GT} )"
@@ -544,7 +568,7 @@ def make_simple_numeric_regex(
 
     Args:
         quantity:
-            Regex for the quantity (e.g. for "sodium" or "Na").
+            Regex for the quantity name (e.g. for "sodium" or "Na").
         units:
             Regex for units.
         value:
@@ -625,6 +649,8 @@ def make_simple_numeric_regex(
         # - Either: quantity [tense] [relation] value [units]
         #   or:     quantity (units value)
         #   or:     quantity (units) [tense] [relation] value
+        # Not preceded by a conditional clause:
+        {EXCLUDE_PRECEDING_CONDITIONAL_CLAUSE}
         # Quantity:
         {group_quantity}
         # Ignorable:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1795,6 +1795,12 @@ Changes
 
 **0.20.10, in progress**
 
+- Fix Python NLP bug that didn't exclude a preceding "if" (e.g. "If CRP is over
+  30 mg/L the ferritin result may be high and uninterpretable"). Applies to
+  all NLP parsers using ``make_simple_numeric_regex``. Also added "below" as
+  additional synonym for "<", and "above" as synonym for ">".
+
+
 To do
 ~~~~~
 


### PR DESCRIPTION
…w inequalities.

Two changes:
* For simple numeric regex, exclude preceding conditionals; e.g. for CRP, exclude "if [the] CRP..." or "when [the] CRP..."
* Also add above/below as additional inequality synonyms.