### PR TITLE
Additional preprocessing steps for SystmOne

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    allowed_updates:
-      - match:
-          update_type: "security"
+    allow:
+      - update-type: "security"

--- a/crate_anon/anonymise/dd.py
+++ b/crate_anon/anonymise/dd.py
@@ -867,6 +867,26 @@ class DataDictionary:
                             f"currently set for {r.src_signature}"
                         )
 
+        log.debug("Checking DD: missing patient identifiers...")
+
+        tables_missing_pids = []
+
+        for d in self.get_source_databases():
+            for t in self.get_src_tables(d):
+                rows = self.get_rows_for_src_table(d, t)
+                primary_pid = any([r.primary_pid for r in rows])
+                master_pid = any([r.master_pid for r in rows])
+
+                if master_pid and not primary_pid:
+                    tables_missing_pids.append(t)
+
+        if tables_missing_pids:
+            missing_string = " ".join(tables_missing_pids)
+            raise ValueError(
+                "These tables have a master PID but no primary PID: "
+                f"{missing_string}. They probably should be omitted."
+            )
+
         log.debug("Checking DD: table consistency...")
         for d, t in self.get_scrub_from_db_table_pairs():
             pid_field = self.get_pid_name(d, t)

--- a/crate_anon/anonymise/ddr.py
+++ b/crate_anon/anonymise/ddr.py
@@ -33,7 +33,6 @@ crate_anon/anonymise/ddr.py
 
 import ast
 import logging
-import re
 from typing import Any, List, Dict, Iterable, Optional, TYPE_CHECKING, Union
 
 from cardinal_pythonlib.convert import convert_to_int
@@ -79,6 +78,7 @@ from crate_anon.common.sql import (
     is_sql_column_type_textual,
     matches_fielddef,
     matches_tabledef,
+    replace_odd_chars,
 )
 
 if TYPE_CHECKING:
@@ -1602,7 +1602,7 @@ class DataDictionaryRow:
         if dbconf.ddgen_convert_odd_chars_to_underscore:
             self.dest_field = str(self.dest_field)  # if this fails,
             # there's a Unicode problem
-            self.dest_field = self.replace_odd_chars(self.dest_field)
+            self.dest_field = replace_odd_chars(self.dest_field)
             # ... this will choke on a Unicode string
 
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1707,7 +1707,7 @@ class DataDictionaryRow:
         if dbconf.ddgen_convert_odd_chars_to_underscore:
             self.dest_table = str(self.dest_table)
             # ... if this fails, there's a Unicode problem
-            self.dest_table = self.replace_odd_chars(self.dest_table)
+            self.dest_table = replace_odd_chars(self.dest_table)
 
         for suffix in dbconf.ddgen_rename_tables_remove_suffixes:
             if self.dest_table.endswith(suffix):
@@ -1786,22 +1786,6 @@ class DataDictionaryRow:
 
         else:
             self.omit = dbconf.ddgen_omit_by_default
-
-    @staticmethod
-    def replace_odd_chars(text: str) -> str:
-        """
-        Sanitise a table or field name to only contain printable ASCII
-        characters plus ()/|
-
-        SQLServer and MySQL allow pretty much anything in a table or field name
-        but these could cause problems elsewhere.
-        """
-
-        # Replace Unicode with underscore
-        text = re.sub(r"[^\x21-\x7F]+", "_", text)
-
-        # Replace invalid ASCII
-        return text.translate({ord(c): "_" for c in "()/|"})
 
     def set_as_table_comment(
         self, src_db: str, src_table: str, comment: str

--- a/crate_anon/anonymise/tests/ddr_tests.py
+++ b/crate_anon/anonymise/tests/ddr_tests.py
@@ -35,18 +35,19 @@ from crate_anon.anonymise.ddr import DataDictionaryRow
 
 
 class DataDictionaryRowTests(TestCase):
-    def test_odd_chars_replaced_in_dest_table(self) -> None:
-        mock_config = mock.Mock()
-        ddr = DataDictionaryRow(mock_config)
-        # unicode n-dash ------------------------v
-        test_table = f"A b(c)d/e|f\tg{chr(0x80)}h–i"
-        test_field = test_table
+    def setUp(self) -> None:
+        super().setUp()
 
-        src_datatype_sqltext = ""  # Arbitrary
-        src_sqla_coltype = String()
-        mock_db_config = mock.Mock(
+        mock_config = mock.Mock()
+        self.ddr = DataDictionaryRow(mock_config)
+
+        self.test_table = "test_table"
+        self.test_field = "test_field"
+
+        self.src_datatype_sqltext = ""  # Arbitrary
+        self.src_sqla_coltype = String()
+        self.mock_db_config = mock.Mock(
             bin2text_dict={},
-            ddgen_convert_odd_chars_to_underscore=True,
             ddgen_extra_hash_fields={},
             ddgen_filename_to_text_fields=[],
             ddgen_force_lower_case=False,
@@ -66,17 +67,53 @@ class DataDictionaryRowTests(TestCase):
             ddgen_scrubsrc_thirdparty_xref_pid_fields=[],
             ddgen_truncate_date_fields=[],
         )
-        ddr.set_from_src_db_info(
-            "test_db",
-            test_table,
-            test_field,
-            src_datatype_sqltext,
-            src_sqla_coltype,
-            mock_db_config,
+
+    def test_odd_chars_replaced_in_dest_table(self) -> None:
+        # Actual replacement tested in common/sql/sql_tests.py. Here we just
+        # make sure that the function is called with the right input.
+        mock_replace_odd_chars = mock.Mock()
+
+        self.mock_db_config.ddgen_convert_odd_chars_to_underscore = True
+
+        with mock.patch.multiple(
+            "crate_anon.anonymise.ddr",
+            replace_odd_chars=mock_replace_odd_chars,
+        ):
+            self.ddr.set_from_src_db_info(
+                "test_db",
+                self.test_table,
+                self.test_field,
+                self.src_datatype_sqltext,
+                self.src_sqla_coltype,
+                self.mock_db_config,
+            )
+
+        mock_replace_odd_chars.assert_has_calls(
+            [
+                mock.call(self.test_table),
+                mock.call(self.test_field),
+            ],
+            any_order=True,
         )
 
-        expected_table = "A_b_c_d_e_f_g_h_i"
-        expected_field = expected_table
+    def test_odd_chars_not_replaced_in_dest_table(self) -> None:
+        # Actual replacement tested in common/sql/sql_tests.py. Here we just
+        # make sure that the function is not called.
+        self.mock_db_config.ddgen_convert_odd_chars_to_underscore = False
 
-        self.assertEqual(ddr.dest_table, expected_table)
-        self.assertEqual(ddr.dest_field, expected_field)
+        mock_replace_odd_chars = mock.Mock()
+
+        with mock.patch.multiple(
+            "crate_anon.anonymise.ddr",
+            replace_odd_chars=mock_replace_odd_chars,
+        ):
+            self.ddr.set_from_src_db_info(
+                "test_db",
+                self.test_table,
+                self.test_field,
+                self.src_datatype_sqltext,
+                self.src_sqla_coltype,
+                self.mock_db_config,
+            )
+
+        mock_replace_odd_chars.assert_not_called()

--- a/crate_anon/common/sql.py
+++ b/crate_anon/common/sql.py
@@ -2514,3 +2514,19 @@ def decorate_index_name(
     if engine.dialect.name == "sqlite":
         return f"{idxname}_{tablename}"
     return idxname
+
+
+def replace_odd_chars(text: str) -> str:
+    """
+    Sanitise a table or field name to only contain printable ASCII
+    characters plus ()/|
+
+    SQLServer and MySQL allow pretty much anything in a table or field name
+    but these could cause problems elsewhere.
+    """
+
+    # Replace Unicode with underscore
+    text = re.sub(r"[^\x21-\x7F]+", "_", text)
+
+    # Replace invalid ASCII
+    return text.translate({ord(c): "_" for c in "()/|'"})

--- a/crate_anon/common/sql.py
+++ b/crate_anon/common/sql.py
@@ -70,7 +70,7 @@ from cardinal_pythonlib.sqlalchemy.schema import (
 )
 from cardinal_pythonlib.timing import MultiTimerContext, timer
 from pyparsing import ParseResults
-from sqlalchemy import inspect
+from sqlalchemy import Connection, inspect
 from sqlalchemy.dialects.mssql.base import MS_2012_VERSION
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.engine.interfaces import Dialect
@@ -1034,6 +1034,25 @@ def execute(engine: Engine, sql: str) -> None:
     else:
         with engine.begin() as connection:
             connection.execute(sql)
+
+
+def connection_execute(connection: Connection, sql: str) -> None:
+    """
+    Executes plain SQL in an existing transaction.
+
+    Whether we act or just print is conditional on previous calls to
+    :func:`set_print_not_execute`.
+
+    Args:
+        connection: SQLAlchemy database Connection
+        sql: raw SQL to execute (or print)
+    """
+    log.debug(sql)
+    if _global_print_not_execute_sql:
+        print(format_sql_for_print(sql) + "\n;")
+        # extra \n in case the SQL ends in a comment
+    else:
+        connection.execute(sql)
 
 
 def add_columns(engine: Engine, table: Table, columns: List[Column]) -> None:

--- a/crate_anon/common/tests/sql_tests.py
+++ b/crate_anon/common/tests/sql_tests.py
@@ -42,6 +42,7 @@ from crate_anon.common.sql import (
     get_first_from_table,
     matches_fielddef,
     matches_tabledef,
+    replace_odd_chars,
 )
 
 log = logging.getLogger(__name__)
@@ -115,3 +116,10 @@ class SqlTests(TestCase):
                 is_sql_column_type_textual(sqltype),
                 f"Should be detected as non-textual: {sqltype}",
             )
+
+    def test_odd_chars_replaced(self) -> None:
+        # unicode n-dash ------------------v
+        test = f"A b(c)d/e|f\tg{chr(0x80)}h–i'j"
+        expected = "A_b_c_d_e_f_g_h_i_j"
+
+        self.assertEqual(replace_odd_chars(test), expected)

--- a/crate_anon/preprocess/constants.py
+++ b/crate_anon/preprocess/constants.py
@@ -48,6 +48,9 @@ CRATE_COL_FILE_PATH = "crate_file_path"
 CRATE_COL_TEXT = "crate_text"
 CRATE_COL_TEXT_LAST_EXTRACTED = "crate_text_last_extracted"
 
+# SystmOne combined address column
+CRATE_COL_FIRST_LINE = "crate_first_line"
+
 # -----------------------------------------------------------------------------
 # Columns in ONS Postcode Database (from CRATE import)
 # -----------------------------------------------------------------------------

--- a/crate_anon/preprocess/preprocess_systmone.py
+++ b/crate_anon/preprocess/preprocess_systmone.py
@@ -247,7 +247,7 @@ def remove_identity_properties(engine: Engine, table: Table) -> None:
     col_type = str(identity_column.type.compile(dialect=engine.dialect))
     tmp_col_name = f"{col_name}_new_tmp"
 
-    log.debug(f"Stripping IDENTITY property from {table.name}.{col_name}...")
+    log.debug(f"Removing IDENTITY property from {table.name}.{col_name}...")
 
     inspector = inspect(engine)
 
@@ -258,13 +258,13 @@ def remove_identity_properties(engine: Engine, table: Table) -> None:
 
     with engine.begin() as connection:
         if is_identity_pk and pk_name:
-            log.debug(f"Dropping primary key constraint: {pk_name}")
+            log.debug(f"Dropping primary key constraint: {pk_name}...")
             connection_execute(
                 connection,
                 text(f"ALTER TABLE {table.name} DROP CONSTRAINT [{pk_name}]"),
             )
 
-        log.debug(f"Creating temporary column: {tmp_col_name}")
+        log.debug(f"Creating temporary column: {tmp_col_name}...")
         connection_execute(
             connection,
             text(
@@ -279,7 +279,7 @@ def remove_identity_properties(engine: Engine, table: Table) -> None:
             text(f"UPDATE {table.name} SET [{tmp_col_name}] = [{col_name}]"),
         )
 
-        log.debug(f"Dropping original identity column: {col_name}")
+        log.debug(f"Dropping original IDENTITY column: {col_name}...")
         connection_execute(
             connection,
             text(f"ALTER TABLE {table.name} DROP COLUMN [{col_name}]"),
@@ -303,9 +303,7 @@ def remove_identity_properties(engine: Engine, table: Table) -> None:
                 ),
             )
 
-    log.debug(
-        f"Successfully converted {table.name}.{col_name} to a standard column."
-    )
+    log.debug(f"Successfully removed IDENTITY from {table.name}.{col_name}.")
 
 
 def preprocess_systmone(

--- a/crate_anon/preprocess/preprocess_systmone.py
+++ b/crate_anon/preprocess/preprocess_systmone.py
@@ -42,10 +42,12 @@ from cardinal_pythonlib.sqlalchemy.schema import (
 from rich_argparse import RawDescriptionRichHelpFormatter
 from sqlalchemy import (
     Column,
+    Computed,
     create_engine,
     Engine,
     inspect,
     MetaData,
+    String,
     text,
     Table,
 )
@@ -66,6 +68,7 @@ from crate_anon.common.sql import (
     set_print_not_execute,
 )
 from crate_anon.preprocess.constants import (
+    CRATE_COL_FIRST_LINE,
     CRATE_COL_PK,
     CRATE_IDX_PREFIX,
     DEFAULT_GEOG_COLS,
@@ -354,6 +357,29 @@ def add_crate_pk_column(engine: Engine, table: Table) -> None:
     add_columns(engine, table, [crate_pk_col])
 
 
+def create_concatenated_address_column(
+    engine: Engine,
+    metadata: MetaData,
+    context: SystmOneContext,
+) -> None:
+    # Better to anonymise "10 Downing Street" rather than all instances of "10"
+    # and "Downing Street"
+    first_line_col = Column(
+        CRATE_COL_FIRST_LINE,
+        String(401),  # 200 + space + 200,
+        Computed("NumberOfBuilding + ' ' + NameOfRoad"),
+        comment="NumberOfBuilding + NameOfRoad",
+        nullable=True,
+    )
+
+    table = metadata.tables[
+        contextual_tablename(S1Table.PATIENT_ADDRESS, context)
+    ]
+
+    table.append_column(first_line_col, replace_existing=True)
+    add_columns(engine, table, [first_line_col])
+
+
 def preprocess_systmone(
     engine: Engine,
     context: SystmOneContext,
@@ -393,18 +419,19 @@ def preprocess_systmone(
             log.debug(f"Skipping table: {table.name}")
             continue
 
+        replace_composite_primary_keys(engine, table)
+
         table_needs_pk = is_in_re(ct, TABLES_REQUIRING_CRATE_PK_REGEX)
 
         # If creating, (1) create pseudo-PK if necessary, (2) create indexes.
         # If dropping, (1) drop indexes, (2) drop pseudo-PK if necessary.
-
-        replace_composite_primary_keys(engine, table)
 
         # Create step #1
         if not drop_danger_drop and table_needs_pk:
             if engine.dialect.name == SqlaDialectName.MSSQL:
                 remove_identity_properties(engine, table)
             add_crate_pk_column(engine, table)
+
         # Create step #2 or drop step #1
         # noinspection PyTypeChecker
 
@@ -464,6 +491,8 @@ def preprocess_systmone(
                 view_name=CrateView.GEOGRAPHY_VIEW,
                 geog_cols=geog_cols,
             )
+
+    create_concatenated_address_column(engine, metadata, context)
 
     # Documents
     if docstore_root:

--- a/crate_anon/preprocess/preprocess_systmone.py
+++ b/crate_anon/preprocess/preprocess_systmone.py
@@ -234,6 +234,27 @@ def add_testpatient_view(
     create_view(engine, view_name, select_sql)
 
 
+def replace_composite_primary_keys(engine: Engine, table: Table) -> None:
+
+    # Currently only one of these within CPFT:
+    # PK_S1_Religion on S1_Religion (RowIdentifier + IDPatient)
+    inspector = inspect(engine)
+
+    pk_constraint = inspector.get_pk_constraint(table.name)
+    pk_name = pk_constraint.get("name")
+    pk_cols = pk_constraint.get("constrained_columns", [])
+
+    if len(pk_cols) <= 1:
+        return
+
+    execute(
+        engine,
+        text(f"ALTER TABLE {table.name} DROP CONSTRAINT [{pk_name}]"),
+    )
+
+    add_crate_pk_column(engine, table)
+
+
 def remove_identity_properties(engine: Engine, table: Table) -> None:
     identity_column = None
     for column in table.columns:
@@ -326,6 +347,13 @@ def replace_odd_chars_in_table(engine: Engine, table: Table) -> None:
             )
 
 
+def add_crate_pk_column(engine: Engine, table: Table) -> None:
+    crate_pk_col = make_bigint_autoincrement_column(CRATE_COL_PK)
+    # SQL Server requires Table-bound columns in order to generate DDL:
+    table.append_column(crate_pk_col, replace_existing=True)
+    add_columns(engine, table, [crate_pk_col])
+
+
 def preprocess_systmone(
     engine: Engine,
     context: SystmOneContext,
@@ -370,15 +398,13 @@ def preprocess_systmone(
         # If creating, (1) create pseudo-PK if necessary, (2) create indexes.
         # If dropping, (1) drop indexes, (2) drop pseudo-PK if necessary.
 
+        replace_composite_primary_keys(engine, table)
+
         # Create step #1
         if not drop_danger_drop and table_needs_pk:
             if engine.dialect.name == SqlaDialectName.MSSQL:
                 remove_identity_properties(engine, table)
-            crate_pk_col = make_bigint_autoincrement_column(CRATE_COL_PK)
-            # SQL Server requires Table-bound columns in order to generate DDL:
-            table.append_column(crate_pk_col, replace_existing=True)
-            add_columns(engine, table, [crate_pk_col])
-
+            add_crate_pk_column(engine, table)
         # Create step #2 or drop step #1
         # noinspection PyTypeChecker
 

--- a/crate_anon/preprocess/preprocess_systmone.py
+++ b/crate_anon/preprocess/preprocess_systmone.py
@@ -372,8 +372,9 @@ def create_concatenated_address_column(
         nullable=True,
     )
 
+    # Table is called "PatientAddress" in CPFT
     table = metadata.tables[
-        contextual_tablename(S1Table.PATIENT_ADDRESS, context)
+        contextual_tablename(S1Table.ADDRESS_HISTORY, context)
     ]
 
     table.append_column(first_line_col, replace_existing=True)

--- a/crate_anon/preprocess/preprocess_systmone.py
+++ b/crate_anon/preprocess/preprocess_systmone.py
@@ -31,22 +31,30 @@ crate_anon/preprocess/preprocess_systmone.py
 
 import argparse
 import logging
-from typing import List, TYPE_CHECKING
+from typing import List
 
 from cardinal_pythonlib.enumlike import keys_descriptions_from_enum
 from cardinal_pythonlib.logs import main_only_quicksetup_rootlogger
+from cardinal_pythonlib.sqlalchemy.dialect import SqlaDialectName
 from cardinal_pythonlib.sqlalchemy.schema import (
     make_bigint_autoincrement_column,
 )
 from rich_argparse import RawDescriptionRichHelpFormatter
-from sqlalchemy.engine import create_engine
-from sqlalchemy.engine.base import Engine
-from sqlalchemy.sql.schema import MetaData
+from sqlalchemy import (
+    Column,
+    create_engine,
+    Engine,
+    inspect,
+    MetaData,
+    text,
+    Table,
+)
 
 from crate_anon.anonymise.constants import AnonymiseConfigDefaults
 from crate_anon.common.sql import (
     add_columns,
     add_indexes,
+    connection_execute,
     create_view,
     drop_columns,
     drop_indexes,
@@ -80,9 +88,6 @@ from crate_anon.preprocess.systmone_ddgen import (
     TABLES_REQUIRING_CRATE_PK_REGEX,
 )
 from crate_anon.preprocess.text_extractor import SystmOneTextExtractor
-
-if TYPE_CHECKING:
-    from sqlalchemy.schema import Column, Table
 
 log = logging.getLogger(__name__)
 
@@ -227,6 +232,82 @@ def add_testpatient_view(
     create_view(engine, view_name, select_sql)
 
 
+def remove_identity_properties(engine: Engine, table: Table) -> None:
+    identity_column = None
+    for column in table.columns:
+        if column.name != CRATE_COL_PK and column.identity is not None:
+            identity_column = column
+            break
+
+    if identity_column is None:
+        log.debug(f"No identity column detected on '{table.name}'.")
+        return
+
+    col_name = identity_column.name
+    col_type = str(identity_column.type.compile(dialect=engine.dialect))
+    tmp_col_name = f"{col_name}_new_tmp"
+
+    log.debug(f"Stripping IDENTITY property from {table.name}.{col_name}...")
+
+    inspector = inspect(engine)
+
+    pk_constraint = inspector.get_pk_constraint(table.name)
+    pk_name = pk_constraint.get("name")
+    pk_cols = pk_constraint.get("constrained_columns", [])
+    is_identity_pk = col_name in pk_cols
+
+    with engine.begin() as connection:
+        if is_identity_pk and pk_name:
+            log.debug(f"Dropping primary key constraint: {pk_name}")
+            connection_execute(
+                connection,
+                text(f"ALTER TABLE {table.name} DROP CONSTRAINT [{pk_name}]"),
+            )
+
+        log.debug(f"Creating temporary column: {tmp_col_name}")
+        connection_execute(
+            connection,
+            text(
+                f"ALTER TABLE {table.name} "
+                f"ADD [{tmp_col_name}] {col_type} NULL"
+            ),
+        )
+
+        log.debug("Copying data to new column...")
+        connection_execute(
+            connection,
+            text(f"UPDATE {table.name} SET [{tmp_col_name}] = [{col_name}]"),
+        )
+
+        log.debug(f"Dropping original identity column: {col_name}")
+        connection_execute(
+            connection,
+            text(f"ALTER TABLE {table.name} DROP COLUMN [{col_name}]"),
+        )
+
+        log.debug(f"Renaming {tmp_col_name} to {col_name}...")
+        connection_execute(
+            connection,
+            text(
+                f"EXEC sp_rename '{table.name}.{tmp_col_name}', "
+                f"'{col_name}', 'COLUMN'"
+            ),
+        )
+
+        if not identity_column.nullable:
+            connection_execute(
+                connection,
+                text(
+                    f"ALTER TABLE {table.name} "
+                    f"ALTER COLUMN [{col_name}] {col_type} NOT NULL"
+                ),
+            )
+
+    log.debug(
+        f"Successfully converted {table.name}.{col_name} to a standard column."
+    )
+
+
 def preprocess_systmone(
     engine: Engine,
     context: SystmOneContext,
@@ -269,6 +350,8 @@ def preprocess_systmone(
 
         # Create step #1
         if not drop_danger_drop and table_needs_pk:
+            if engine.dialect.name == SqlaDialectName.MSSQL:
+                remove_identity_properties(engine, table)
             crate_pk_col = make_bigint_autoincrement_column(CRATE_COL_PK)
             # SQL Server requires Table-bound columns in order to generate DDL:
             table.append_column(crate_pk_col, replace_existing=True)
@@ -276,7 +359,9 @@ def preprocess_systmone(
 
         # Create step #2 or drop step #1
         # noinspection PyTypeChecker
-        for column in table.columns:  # type: Column
+
+        column: Column
+        for column in table.columns:
             colname = column.name
             idxname = f"{CRATE_IDX_PREFIX}_{colname}"
             if (

--- a/crate_anon/preprocess/preprocess_systmone.py
+++ b/crate_anon/preprocess/preprocess_systmone.py
@@ -60,7 +60,9 @@ from crate_anon.common.sql import (
     drop_indexes,
     drop_view,
     ensure_columns_present,
+    execute,
     IndexCreationInfo,
+    replace_odd_chars,
     set_print_not_execute,
 )
 from crate_anon.preprocess.constants import (
@@ -247,7 +249,7 @@ def remove_identity_properties(engine: Engine, table: Table) -> None:
     col_type = str(identity_column.type.compile(dialect=engine.dialect))
     tmp_col_name = f"{col_name}_new_tmp"
 
-    log.debug(f"Removing IDENTITY property from {table.name}.{col_name}...")
+    log.info(f"Removing IDENTITY property from {table.name}.{col_name}...")
 
     inspector = inspect(engine)
 
@@ -303,7 +305,25 @@ def remove_identity_properties(engine: Engine, table: Table) -> None:
                 ),
             )
 
-    log.debug(f"Successfully removed IDENTITY from {table.name}.{col_name}.")
+    log.info(f"Successfully removed IDENTITY from {table.name}.{col_name}.")
+
+
+def replace_odd_chars_in_table(engine: Engine, table: Table) -> None:
+    for column in table.columns:
+        sanitised_column_name = replace_odd_chars(column.name)
+
+        escaped_column_name = column.name.replace("'", "''").replace(
+            ":", "\\:"
+        )
+
+        if column.name != sanitised_column_name:
+            execute(
+                engine,
+                text(
+                    f"EXEC sp_rename '{table.name}.[{escaped_column_name}]', "
+                    f"'{sanitised_column_name}', 'COLUMN'"
+                ),
+            )
 
 
 def preprocess_systmone(
@@ -332,6 +352,10 @@ def preprocess_systmone(
     for table in sorted(
         metadata.tables.values(), key=lambda t: t.name.lower()
     ):  # type: Table
+
+        if engine.dialect.name == SqlaDialectName.MSSQL:
+            replace_odd_chars_in_table(engine, table)
+
         ct = core_tablename(
             table.name,
             from_context=context,

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -2362,16 +2362,6 @@ def get_scrub_alter_details(
 
         return ssi
 
-    # -------------------------------------------------------------------------
-    # Proceed for all other tables.
-    # -------------------------------------------------------------------------
-    handled = process_generic_table_column(
-        tablename=tablename, colname=colname, ddr=ddr, ssi=ssi, context=context
-    )
-    if handled:
-        # Recognized and handled as a generic column.
-        return ssi
-
     if eq(tablename, S1Table.ADDRESS_HISTORY):
         # ---------------------------------------------------------------------
         # Address table.
@@ -2393,7 +2383,17 @@ def get_scrub_alter_details(
             # CPFTAddressCol.POSTCODE_NOSPACE
             pass
 
-    elif eq(tablename, S1Table.CONTACT_DETAILS):
+    # -------------------------------------------------------------------------
+    # Proceed for all other tables.
+    # -------------------------------------------------------------------------
+    handled = process_generic_table_column(
+        tablename=tablename, colname=colname, ddr=ddr, ssi=ssi, context=context
+    )
+    if handled:
+        # Recognized and handled as a generic column.
+        return ssi
+
+    if eq(tablename, S1Table.CONTACT_DETAILS):
         # ---------------------------------------------------------------------
         # Contact details table.
         # ---------------------------------------------------------------------
@@ -2687,6 +2687,7 @@ def annotate_systmone_dd_row(
         from_context=context,
         allow_unprefixed=allow_unprefixed_tables,
     )
+
     if not tablename:
         # It didn't have the right prefix and allow_unprefixed_tables is False.
         ddr.decision = Decision.OMIT

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -439,7 +439,7 @@ from crate_anon.anonymise.constants import (
 )
 from crate_anon.common.logfunc import warn_once
 from crate_anon.anonymise.dd import DataDictionary, DataDictionaryRow
-from crate_anon.preprocess.constants import CRATE_COL_PK
+from crate_anon.preprocess.constants import CRATE_COL_FIRST_LINE, CRATE_COL_PK
 
 log = logging.getLogger(__name__)
 
@@ -1261,6 +1261,7 @@ COLS_ADDRESS_PHRASES = (
     S1AddressCol.LOCALITY,
     S1AddressCol.TOWN,
     S1AddressCol.COUNTY,
+    CRATE_COL_FIRST_LINE,  # Generated column e.g. 10 Downing Street
 )
 COLS_ADDRESS_PHRASE_UNLESS_NUMBER = (
     S1AddressCol.BUILDING_NAME,
@@ -2362,25 +2363,33 @@ def get_scrub_alter_details(
         return ssi
 
     if eq(tablename, S1Table.ADDRESS_HISTORY):
+        handled = False
+
         # ---------------------------------------------------------------------
         # Address table.
         # ---------------------------------------------------------------------
         if is_in(colname, COLS_ADDRESS_PHRASES):
             ssi.scrub_src = ScrubSrc.PATIENT
             ssi.scrub_method = ScrubMethod.PHRASE
+            handled = True
 
         elif is_in(colname, COLS_ADDRESS_PHRASE_UNLESS_NUMBER):
             ssi.scrub_src = ScrubSrc.PATIENT
             ssi.scrub_method = ScrubMethod.PHRASE_UNLESS_NUMERIC
+            handled = True
 
         elif eq(colname, S1AddressCol.POSTCODE):
             ssi.scrub_src = ScrubSrc.PATIENT
             ssi.scrub_method = ScrubMethod.CODE
+            handled = True
 
         else:
             # omit anything else in the address table, e.g.
             # CPFTAddressCol.POSTCODE_NOSPACE
             pass
+
+        if handled:
+            return ssi
 
     # -------------------------------------------------------------------------
     # Proceed for all other tables.

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -591,7 +591,6 @@ class S1Table:
     NOMIS_NUMBER = "NomisNumber"  # National Offender Management Info. System
     OUT_OF_HOURS_ACTION = "OohAction"
     OUT_OF_HOURS_THIRD_PARTY_CALL = "OohThirdPartyCall"
-    PATIENT_ADDRESS = "PatientAddress"
     RELIGION = "Religion"
     SAFEGUARDING_ALLEGATION_DETAILS = "SafeguardingAllegationDetails"
     SAFEGUARDING_INCIDENT_DETAILS = "SafeguardingIncidentDetails"
@@ -2687,7 +2686,6 @@ def annotate_systmone_dd_row(
         from_context=context,
         allow_unprefixed=allow_unprefixed_tables,
     )
-
     if not tablename:
         # It didn't have the right prefix and allow_unprefixed_tables is False.
         ddr.decision = Decision.OMIT

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -582,6 +582,7 @@ class S1Table:
 
     ACTIVITY_EVENT = "ActivityEvent"
     BED_CLOSURE = "BedClosure"
+    CLINICAL_OUTCOME_GOAL_BASED = "ClinicalOutcome_GoalBased"
     CONTACTS = "Contacts"
     DISCHARGE_DELAY = "DischargeDelay"
     DOCUMENTS = "Documents"
@@ -590,6 +591,7 @@ class S1Table:
     NOMIS_NUMBER = "NomisNumber"  # National Offender Management Info. System
     OUT_OF_HOURS_ACTION = "OohAction"
     OUT_OF_HOURS_THIRD_PARTY_CALL = "OohThirdPartyCall"
+    RELIGION = "Religion"
     SAFEGUARDING_ALLEGATION_DETAILS = "SafeguardingAllegationDetails"
     SAFEGUARDING_INCIDENT_DETAILS = "SafeguardingIncidentDetails"
     TASK = "Task"
@@ -1557,12 +1559,14 @@ _NOT_PK_TABLENAME_COLNAME_REGEX_PAIRS_S1 = tuple(
     (terminate(t), S1GenericCol.ROW_ID)
     for t in (
         S1Table.ACTIVITY_EVENT,
+        S1Table.BED_CLOSURE,
         S1Table.CARE_PLAN_REVIEW,
+        S1Table.CLINICAL_OUTCOME_GOAL_BASED,
         S1Table.DISCHARGE_DELAY,
         S1Table.FREETEXT,  # see also TABLES_REQUIRING_CRATE_PK_REGEX above
-        S1Table.BED_CLOSURE,
         S1Table.MENTAL_HEALTH_ACT_APPEAL,
         S1Table.MENTAL_HEALTH_ACT_AWOL,
+        S1Table.RELIGION,
         S1Table.TASK,
     )
 ) + tuple(

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -758,6 +758,9 @@ _OMIT_AND_IGNORE_TABLES_REGEX_CPFT = (
     # RiO "ClientID" columns, and it's not clear they add much.
     "UserSmartCard",
     # Not relevant clinically.
+    "vw_SmokingDataReport",
+    # vw_SmokingDataReport and vw_SmokingDataReport2 have errors:
+    # Invalid object name 'SystmOne.dbo.SRCode'
     # I considered excluding "vw.*" (views) and "zzz.*" (scratch tables) here,
     # but the user has the option to exclude all such tables via
     # --systmone_allow_unprefixed_tables if they desire. Views may be useful;

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -439,7 +439,14 @@ from crate_anon.anonymise.constants import (
 )
 from crate_anon.common.logfunc import warn_once
 from crate_anon.anonymise.dd import DataDictionary, DataDictionaryRow
-from crate_anon.preprocess.constants import CRATE_COL_FIRST_LINE, CRATE_COL_PK
+from crate_anon.preprocess.constants import (
+    CRATE_COL_FILE_PATH,
+    CRATE_COL_FIRST_LINE,
+    CRATE_COL_PK,
+    CRATE_COL_TEXT,
+    CRATE_COL_TEXT_LAST_EXTRACTED,
+    CRATE_TABLE_EXTRACTED_TEXT,
+)
 
 log = logging.getLogger(__name__)
 
@@ -681,6 +688,7 @@ class CrateView:
 _INCLUDE_TABLES_REGEX_S1 = (
     # Include even if --systmone_allow_unprefixed_tables is not used.
     CrateView.CRATE_VIEW_PREFIX,
+    CRATE_TABLE_EXTRACTED_TEXT,
 )
 _INCLUDE_TABLES_REGEX_CPFT = ("vw",)  # some other views
 INCLUDE_TABLES_REGEX = {
@@ -1229,6 +1237,8 @@ OMIT_TABLENAME_COLNAME_PAIRS_S1 = (
     # ... out-of-hours calls; details can sometimes contain phone numbers
     (S1Table.OUT_OF_HOURS_THIRD_PARTY_CALL, "Contact"),  # free text
     (S1Table.SAFEGUARDING_INCIDENT_DETAILS, "PoliceReference"),
+    (CRATE_TABLE_EXTRACTED_TEXT, CRATE_COL_FILE_PATH),
+    (CRATE_TABLE_EXTRACTED_TEXT, CRATE_COL_TEXT_LAST_EXTRACTED),
 )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1365,6 +1375,7 @@ _FREETEXT_TABLENAME_COLNAME_REGEX_PAIRS_S1 = (
         "Outcome$",
     ),  # only 100 chars -- but OMIT whole table, as above
     ("SpecialNotes$", "Note$"),  # 8000 char free text
+    (terminate(CRATE_TABLE_EXTRACTED_TEXT), terminate(CRATE_COL_TEXT)),
 )
 _FREETEXT_TABLENAME_COLNAME_REGEX_PAIRS_CPFT = (
     # CPFT:
@@ -1569,6 +1580,7 @@ _NOT_PK_TABLENAME_COLNAME_REGEX_PAIRS_S1 = tuple(
         S1Table.MENTAL_HEALTH_ACT_AWOL,
         S1Table.RELIGION,
         S1Table.TASK,
+        CRATE_TABLE_EXTRACTED_TEXT,
     )
 ) + tuple(
     # Also, if we insert a CRATE PK, then the "RowIdentifier" can't be the PK.

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -761,6 +761,9 @@ _OMIT_AND_IGNORE_TABLES_REGEX_CPFT = (
     "vw_SmokingDataReport",
     # vw_SmokingDataReport and vw_SmokingDataReport2 have errors:
     # Invalid object name 'SystmOne.dbo.SRCode'
+    "vw_Under18AdmissionsToAdult",
+    # View fails with:
+    # Invalid object name 'CPFT_HL7.dbo.HL7_BedMove'
     # I considered excluding "vw.*" (views) and "zzz.*" (scratch tables) here,
     # but the user has the option to exclude all such tables via
     # --systmone_allow_unprefixed_tables if they desire. Views may be useful;

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -734,9 +734,15 @@ _OMIT_AND_IGNORE_TABLES_REGEX_CPFT = (
     #   infection.
     # - No detail suggesting identification (and they don't indicate e.g.
     #   membership of a specific Trust, or a specific job role).
+    "ClinicalOutcome_PairedHoNOS",
+    # Has NHS number but no patient ID so will fail anonymisation
     "Inpatients",
     # S1_Inpatients, S1_Inpatients_20201020: current inpatients -- but these
     # tables have NHSNumber as FLOAT. Exclude them.
+    "LADSAdults_Output",
+    # Has NHS number but no patient ID so will fail anonymisation
+    "LADSCYP_Output",
+    # Has NHS number but no patient ID so will fail anonymisation
     "Mortality",  # includes S1_Mortality, S1_MortalityAdditionalInfo
     # These contain (a) age (rather than DOB) information, and (b) information
     # from multiple systems -- some risk of including RiO patients with
@@ -745,6 +751,8 @@ _OMIT_AND_IGNORE_TABLES_REGEX_CPFT = (
     "ReferralsOpen$",
     # This CPFT table is a non-patient table (but with potentially identifiable
     # information about referral reason? -- maybe not) -- skip it.
+    "SummaryCareRecordInformationGovernance",
+    # Has NHS number but no patient ID so will fail anonymisation
     "WaitList_",  # S1_Waitlist_*
     # Waiting list tables use a confusing blend of SystmOne "IDPatient" and
     # RiO "ClientID" columns, and it's not clear they add much.

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -591,6 +591,7 @@ class S1Table:
     NOMIS_NUMBER = "NomisNumber"  # National Offender Management Info. System
     OUT_OF_HOURS_ACTION = "OohAction"
     OUT_OF_HOURS_THIRD_PARTY_CALL = "OohThirdPartyCall"
+    PATIENT_ADDRESS = "PatientAddress"
     RELIGION = "Religion"
     SAFEGUARDING_ALLEGATION_DETAILS = "SafeguardingAllegationDetails"
     SAFEGUARDING_INCIDENT_DETAILS = "SafeguardingIncidentDetails"

--- a/github_action_scripts/python_checks.sh
+++ b/github_action_scripts/python_checks.sh
@@ -24,4 +24,6 @@ echo checking packages for vulnerabilities
 #       believe that this vulnerability isn't valid because
 #       users shouldn't use untrusted templates without
 #       sandboxing.
-${SAFETY} check --full-report --ignore=67599 --ignore=70612
+# SFTY-20260617-22444. pdfkit is no longer maintained. We will switch
+#       from wkhtmltopdf to weasyprint
+${SAFETY} check --full-report --ignore=67599 --ignore=70612 --ignore=SFTY-20260617-22444

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ INSTALL_REQUIRES = [
     "pyexcel-xlsx==0.6.0",  # for writing XLSX files (using openpyxl)
     "pygments==2.20.0",  # syntax highlighting
     "pyparsing==2.4.7",  # generic grammar parser
-    "pypdf==6.10.1",  # create PDF files
+    "pypdf==6.12.1",  # create PDF files
     "python-dateutil==2.8.1",  # [pin exact version from cardinal_pythonlib]
     # "python-docx==0.8.10",  # needs lxml, which has Visual C++ dependencies under Windows  # noqa: E501
     # ... https://python-docx.readthedocs.org/en/latest/user/install.html

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ INSTALL_REQUIRES = [
     "pyexcel-xlsx==0.6.0",  # for writing XLSX files (using openpyxl)
     "pygments==2.20.0",  # syntax highlighting
     "pyparsing==2.4.7",  # generic grammar parser
-    "pypdf==6.14.0",  # create PDF files
+    "pypdf==6.14.1",  # create PDF files
     "python-dateutil==2.8.1",  # [pin exact version from cardinal_pythonlib]
     # "python-docx==0.8.10",  # needs lxml, which has Visual C++ dependencies under Windows  # noqa: E501
     # ... https://python-docx.readthedocs.org/en/latest/user/install.html

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ INSTALL_REQUIRES = [
     "flake8==5.0.4",  # code checks, keep in sync with .pre-commit-config.yaml
     "docutils==0.19",
     "mistune==3.2.1",
-    "paramiko==4.0.0",  # Python implementation of the SSHv2 protocol, required by faker-file  # noqa: E501
+    "paramiko==5.0.0",  # Python implementation of the SSHv2 protocol, required by faker-file  # noqa: E501
     "pre-commit==2.20.0",  # development only, various sanity checks on code
     "pytest==9.0.3",  # automatic testing
     "pytest-django==4.5.2",  # automatic testing

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ INSTALL_REQUIRES = [
     "requests==2.33.0",  # HTTP requests
     "tornado==6.5.5",  # web framework
     "transaction==3.0.0",  # generic transaction management
-    "urllib3==2.6.3",  # used by requests
+    "urllib3==2.7.0",  # used by requests
     "waitress==3.0.1",  # pure-Python WSGI server
     "zope.sqlalchemy==1.3",  # Zope/SQLAlchemy transaction integration
     # -------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ INSTALL_REQUIRES = [
     "pyexcel-xlsx==0.6.0",  # for writing XLSX files (using openpyxl)
     "pygments==2.20.0",  # syntax highlighting
     "pyparsing==2.4.7",  # generic grammar parser
-    "pypdf==6.13.3",  # create PDF files
+    "pypdf==6.14.0",  # create PDF files
     "python-dateutil==2.8.1",  # [pin exact version from cardinal_pythonlib]
     # "python-docx==0.8.10",  # needs lxml, which has Visual C++ dependencies under Windows  # noqa: E501
     # ... https://python-docx.readthedocs.org/en/latest/user/install.html

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ INSTALL_REQUIRES = [
     "openpyxl==3.0.7",  # read Excel (slower?)
     "ordered-set==4.1.0",  # ordered sets; search for ordered_set
     "pendulum==2.1.2",  # dates/times
-    "Pillow==12.2.0",  # image processing; import as PIL (Python Imaging Library)  # noqa: E501
+    "Pillow==12.3.0",  # image processing; import as PIL (Python Imaging Library)  # noqa: E501
     "pdfkit==0.6.1",  # interface to wkhtmltopdf
     "prettytable==3.2.0",  # pretty formating of text-based tables
     "psutil==6.1.1",  # process management, cardinal_pythonlib dependency, not currently used  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ INSTALL_REQUIRES = [
     "faker-file[common]==0.17.13",  # test file creation
     "flake8==5.0.4",  # code checks, keep in sync with .pre-commit-config.yaml
     "docutils==0.19",
-    "mistune==3.2.1",
+    "mistune==3.3.0",
     "paramiko==5.0.0",  # Python implementation of the SSHv2 protocol, required by faker-file  # noqa: E501
     "pre-commit==2.20.0",  # development only, various sanity checks on code
     "pytest==9.0.3",  # automatic testing

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ INSTALL_REQUIRES = [
     "faker-file[common]==0.17.13",  # test file creation
     "flake8==5.0.4",  # code checks, keep in sync with .pre-commit-config.yaml
     "docutils==0.19",
-    "mistune<2.0.0",  # API documentation, 2.0.0 not compatible
+    "mistune==3.2.1",
     "paramiko==3.4.1",  # Python implementation of the SSHv2 protocol, required by faker-file  # noqa: E501
     "pre-commit==2.20.0",  # development only, various sanity checks on code
     "pytest==9.0.3",  # automatic testing
@@ -156,7 +156,8 @@ INSTALL_REQUIRES = [
     "python-on-whales==0.68.0",  # python wrappers for testing with Docker
     "sphinx==7.1.2",  # documentation
     "sphinx_rtd_theme==3.0.2",  # documentation
-    "sphinxcontrib-openapi==0.7.0",  # API documentation
+    "sphinx-mdinclude==0.6.2",  # documentation
+    "sphinxcontrib-openapi==0.9.0",  # API documentation
     # ---------------------------------------------------------------------
     # For database connections (see manual): install manually
     # ---------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ INSTALL_REQUIRES = [
     "pyramid_tm==2.4",  # Pyramid transaction management
     "redis==4.5.4",  # interface to Redis in-memory key-value database
     "requests==2.33.0",  # HTTP requests
-    "tornado==6.5.6",  # web framework
+    "tornado==6.5.7",  # web framework
     "transaction==3.0.0",  # generic transaction management
     "urllib3==2.7.0",  # used by requests
     "waitress==3.0.1",  # pure-Python WSGI server

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ INSTALL_REQUIRES = [
     "pyexcel-xlsx==0.6.0",  # for writing XLSX files (using openpyxl)
     "pygments==2.20.0",  # syntax highlighting
     "pyparsing==2.4.7",  # generic grammar parser
-    "pypdf==6.14.1",  # create PDF files
+    "pypdf==6.14.2",  # create PDF files
     "python-dateutil==2.8.1",  # [pin exact version from cardinal_pythonlib]
     # "python-docx==0.8.10",  # needs lxml, which has Visual C++ dependencies under Windows  # noqa: E501
     # ... https://python-docx.readthedocs.org/en/latest/user/install.html

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ INSTALL_REQUIRES = [
     # Packages for cloud NLP:
     # -------------------------------------------------------------------------
     "bcrypt==3.2.2",  # bcrypt encryption
-    "cryptography==46.0.7",  # cryptography library
+    "cryptography==48.0.1",  # cryptography library
     # "mysqlclient",  # database access
     "paste==3.4.2",  # middleware; https://github.com/cdent/paste/
     "pyramid==1.10.8",  # Pyramid web framework

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ INSTALL_REQUIRES = [
     "flake8==5.0.4",  # code checks, keep in sync with .pre-commit-config.yaml
     "docutils==0.19",
     "mistune==3.2.1",
-    "paramiko==3.4.1",  # Python implementation of the SSHv2 protocol, required by faker-file  # noqa: E501
+    "paramiko==4.0.0",  # Python implementation of the SSHv2 protocol, required by faker-file  # noqa: E501
     "pre-commit==2.20.0",  # development only, various sanity checks on code
     "pytest==9.0.3",  # automatic testing
     "pytest-django==4.5.2",  # automatic testing

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ INSTALL_REQUIRES = [
     "gutenbergpy==0.3.4",  # Project Gutenberg API
     "jsonlines==3.0.0",  # JSON Lines format
     "kombu==5.3.7",  # AMQP library for Celery; requires VC++ under Windows
-    "mako==1.2.2",  # templates with Python in
+    "mako==1.3.12",  # templates with Python in
     "MarkupSafe==2.0.1",  # for HTML escaping
     # mmh3 requires VC++
     "mmh3==2.5.1",  # MurmurHash, for fast non-cryptographic hashing; optionally used by cardinal_pythonlib; requires VC++ under Windows?  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ INSTALL_REQUIRES = [
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs
     "distro==1.5.0",  # replaces platform.linux_distribution
-    "django==5.2.14",  # for main CRATE research database web server
+    "django==5.2.15",  # for main CRATE research database web server
     "django-debug-toolbar==6.3.0",  # Django debug toolbar
     # "django-debug-toolbar-template-profiler==2.0.1",  # v1.0.1 removed 2017-01-30: division by zero when rendering time is zero  # noqa: E501
     "django-extensions==3.1.1",  # for graph_models, show_urls etc.

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ INSTALL_REQUIRES = [
     "pyexcel-xlsx==0.6.0",  # for writing XLSX files (using openpyxl)
     "pygments==2.20.0",  # syntax highlighting
     "pyparsing==2.4.7",  # generic grammar parser
-    "pypdf==6.13.0",  # create PDF files
+    "pypdf==6.13.3",  # create PDF files
     "python-dateutil==2.8.1",  # [pin exact version from cardinal_pythonlib]
     # "python-docx==0.8.10",  # needs lxml, which has Visual C++ dependencies under Windows  # noqa: E501
     # ... https://python-docx.readthedocs.org/en/latest/user/install.html

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ INSTALL_REQUIRES = [
     "pyramid_tm==2.4",  # Pyramid transaction management
     "redis==4.5.4",  # interface to Redis in-memory key-value database
     "requests==2.33.0",  # HTTP requests
-    "tornado==6.5.5",  # web framework
+    "tornado==6.5.6",  # web framework
     "transaction==3.0.0",  # generic transaction management
     "urllib3==2.7.0",  # used by requests
     "waitress==3.0.1",  # pure-Python WSGI server

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ INSTALL_REQUIRES = [
     "pyexcel-xlsx==0.6.0",  # for writing XLSX files (using openpyxl)
     "pygments==2.20.0",  # syntax highlighting
     "pyparsing==2.4.7",  # generic grammar parser
-    "pypdf==6.12.1",  # create PDF files
+    "pypdf==6.13.0",  # create PDF files
     "python-dateutil==2.8.1",  # [pin exact version from cardinal_pythonlib]
     # "python-docx==0.8.10",  # needs lxml, which has Visual C++ dependencies under Windows  # noqa: E501
     # ... https://python-docx.readthedocs.org/en/latest/user/install.html

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ INSTALL_REQUIRES = [
     "openpyxl==3.0.7",  # read Excel (slower?)
     "ordered-set==4.1.0",  # ordered sets; search for ordered_set
     "pendulum==2.1.2",  # dates/times
-    "Pillow==12.1.1",  # image processing; import as PIL (Python Imaging Library)  # noqa: E501
+    "Pillow==12.2.0",  # image processing; import as PIL (Python Imaging Library)  # noqa: E501
     "pdfkit==0.6.1",  # interface to wkhtmltopdf
     "prettytable==3.2.0",  # pretty formating of text-based tables
     "psutil==6.1.1",  # process management, cardinal_pythonlib dependency, not currently used  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ INSTALL_REQUIRES = [
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs
     "distro==1.5.0",  # replaces platform.linux_distribution
-    "django==5.2.13",  # for main CRATE research database web server
+    "django==5.2.14",  # for main CRATE research database web server
     "django-debug-toolbar==6.3.0",  # Django debug toolbar
     # "django-debug-toolbar-template-profiler==2.0.1",  # v1.0.1 removed 2017-01-30: division by zero when rendering time is zero  # noqa: E501
     "django-extensions==3.1.1",  # for graph_models, show_urls etc.


### PR DESCRIPTION
This incorporates into our SystmOne preprocessing some additional steps that we were previously doing manually:

* Replace any odd characters and spaces in source column names with underscores. SQL server doesn't mind these and it may be possible to coax CRATE to handle them with copious use of square brackets but Excel will remove double spaces from the data dictionary and we can't really expect users to have turned that feature off. We were already doing this in the destination database.
* Replace composite primary keys with `crate_pk`. Only `S1_Religion` is affected in CPFT
* Remove any IDENTITY properties prior to adding `crate_pk`. There can only be one per table.
* Fix the data dictionary defaults for the patient address table
* Add a computed column for the first line of an address in the patient address table so "10 Downing Street" will be scrubbed rather than all instances of "10" and "Downing Street". Building names are still scrubbed separately.
* Omit more problematic tables and views
* Include the `crate_extracted_text` table

I've also added a data dictionary check for tables with a master PID and no primary PID. These will be selected by the anonymiser as patient tables but then fail anonymisation because of the lack of PID.

In the future, we could move hard-coded tables and column names to the configuration.

Tested on CPFT SystmOne database.